### PR TITLE
add React 16 support

### DIFF
--- a/example/src/App.jsx
+++ b/example/src/App.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import RaisedButton from 'material-ui/RaisedButton';
 
 import { connect } from 'react-redux';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@sustainhawaii/mui-redux-alerts",
-  "version": "0.2.2",
+  "name": "mui-redux-alerts",
+  "version": "0.2.0",
   "description": "Material-UI + Redux Dialogs and Snackbars",
   "main": "./lib/index.js",
   "scripts": {
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/SustainHawaii/mui-redux-alerts.git"
+    "url": "git+https://github.com/ThadeuLuz/mui-redux-alerts.git"
   },
   "keywords": [
     "Material-UI",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mui-redux-alerts",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Material-UI + Redux Dialogs and Snackbars",
   "main": "./lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mui-redux-alerts",
+  "name": "@sustainhawaii/mui-redux-alerts",
   "version": "0.2.1",
   "description": "Material-UI + Redux Dialogs and Snackbars",
   "main": "./lib/index.js",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "eslint-plugin-react": "^6.10.3",
     "material-ui": "^0.17.1",
     "react": "^15.4.2",
+    "prop-types": "^15.6.0",
     "rimraf": "^2.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ThadeuLuz/mui-redux-alerts.git"
+    "url": "git+https://github.com/SustainHawaii/mui-redux-alerts.git"
   },
   "keywords": [
     "Material-UI",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sustainhawaii/mui-redux-alerts",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Material-UI + Redux Dialogs and Snackbars",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/Alerts.jsx
+++ b/src/Alerts.jsx
@@ -1,4 +1,6 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
+
 
 import Snackbar from 'material-ui/Snackbar';
 import Dialog from 'material-ui/Dialog';

--- a/src/index.js
+++ b/src/index.js
@@ -6,4 +6,4 @@ export {
   openSnackbar,
   closeDialog,
   closeSnackbar,
-} from './redux.js';
+} from './redux';


### PR DESCRIPTION
This PR adds support for React 16 by using the prop-types module instead of the deprecated PropTypes from the react module.